### PR TITLE
JTS TestRunner which supports most Centroid and ConvexHull cases.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "jts-test-runner"
+version = "0.1.0"
+authors = ["Michael Kirk <michael.code@endoftheworl.de>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+approx = "0.4.0"
+geo = "*"
+include_dir = { version = "0.6", features = ["search"] }
+log = "0.4.14"
+serde =  { version = "*", features = ["derive"] }
+serde-xml-rs = "*"
+wkt = { version = "0.9", features = ["geo-types", "serde"] }
+
+[dev-dependencies]
+pretty_env_logger = "*"
+
+[patch.crates-io]
+geo = { git = "https://github.com/georust/geo", branch = "mkirk/jts-test-runner" }
+geo-types = { git = "https://github.com/georust/geo", branch = "mkirk/jts-test-runner" }
+wkt = { git = "https://github.com/georust/wkt", branch = "mkirk/deserialize-point" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,6 @@ wkt = { version = "0.9", features = ["geo-types", "serde"] }
 pretty_env_logger = "*"
 
 [patch.crates-io]
-geo = { git = "https://github.com/georust/geo", branch = "mkirk/jts-test-runner" }
-geo-types = { git = "https://github.com/georust/geo", branch = "mkirk/jts-test-runner" }
-wkt = { git = "https://github.com/georust/wkt", branch = "mkirk/deserialize-point" }
+geo = { git = "https://github.com/georust/geo", branch = "mkirk/centroid-fixups" }
+geo-types = { git = "https://github.com/georust/geo", branch = "mkirk/centroid-fixups" }
+wkt = { git = "https://github.com/georust/wkt" }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,0 +1,115 @@
+use geo::{Point, Geometry};
+use serde::Deserialize;
+
+use super::Result;
+
+/// Example of the XML that these structures represent
+///
+/// ```xml
+/// <run>
+/// <precisionModel scale="1.0" offsetx="0.0" offsety="0.0"/>
+///
+/// <case>
+/// <desc>AA disjoint</desc>
+/// <a>
+/// POLYGON(
+/// (0 0, 80 0, 80 80, 0 80, 0 0))
+/// </a>
+/// <b>
+/// POLYGON(
+/// (100 200, 100 140, 180 140, 180 200, 100 200))
+/// </b>
+/// <test><op name="relate" arg3="FF2FF1212" arg1="A" arg2="B"> true </op>
+/// </test>
+/// <test>  <op name="intersects" arg1="A" arg2="B">   false   </op></test>
+/// <test>  <op name="contains" arg1="A" arg2="B">   false   </op></test>
+/// </case>
+/// </run>
+/// ```
+#[derive(Debug, Deserialize)]
+pub(crate) struct Run {
+    #[serde(rename="case")]
+    pub cases: Vec<Case>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct Case {
+    pub(crate) desc: String,
+    // `a` seems to always be a WKT geometry, but until we can handle `POINT EMPTY` this
+    // will error.
+    // see https://github.com/georust/wkt/issues/61
+    //
+    // I also spent some time trying to have serde "try" to deserialize, skipping any
+    // cases that were unparseable, without throwing away the whole thing but eventually ran out of time.
+    // See https://github.com/serde-rs/serde/issues/1583 for a related approach
+    //#[serde(deserialize_with = "wkt::deserialize_geometry")]
+    pub(crate) a: String,
+    #[serde(rename = "test")]
+    pub(crate) tests: Vec<Test>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct Test {
+    #[serde(rename="op")]
+    pub(crate) operation_input: OperationInput,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CentroidInput {
+    pub(crate) arg1: String,
+
+    #[serde(rename = "$value")]
+    #[serde(deserialize_with = "wkt::deserialize_point")]
+    pub(crate) expected: Option<geo::Point<f64>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ConvexHullInput {
+    pub(crate) arg1: String,
+
+    #[serde(rename = "$value")]
+    #[serde(deserialize_with = "wkt::deserialize_geometry")]
+    pub(crate) expected: geo::Geometry<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "name")]
+pub(crate) enum OperationInput {
+    #[serde(rename = "getCentroid")]
+    CentroidInput(CentroidInput),
+
+    #[serde(rename = "convexhull")]
+    ConvexHullInput(ConvexHullInput),
+
+    #[serde(other)]
+    Unsupported,
+}
+
+#[derive(Debug)]
+pub(crate) enum Operation {
+    Centroid {
+        subject: Geometry<f64>,
+        expected: Option<Point<f64>>,
+    },
+    ConvexHull {
+        subject: Geometry<f64>,
+        expected: Geometry<f64>,
+    }
+}
+
+impl OperationInput {
+    pub(crate) fn into_operation(self, geometry: Geometry<f64>) -> Result<Operation>
+    {
+        match self {
+            Self::CentroidInput(centroid_input) => {
+                assert_eq!("A", centroid_input.arg1);
+                Ok(Operation::Centroid { subject: geometry.clone(), expected: centroid_input.expected })
+            }
+            Self::ConvexHullInput(convex_hull_input) => {
+                assert_eq!("A", convex_hull_input.arg1);
+                Ok(Operation::ConvexHull { subject: geometry.clone(), expected: convex_hull_input.expected })
+            }
+            Self::Unsupported => Err("This OperationInput not supported".into())
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,82 @@
+#[macro_use]
+extern crate log;
+
+mod input;
+use input::Operation;
+
+mod runner;
+pub use runner::TestRunner;
+
+type Error = Box<dyn std::error::Error>;
+type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn init_logging() {
+        use std::sync::Once;
+        static LOG_SETUP: Once = Once::new();
+        LOG_SETUP.call_once(|| {
+            pretty_env_logger::init();
+        });
+    }
+
+    #[test]
+    fn test_centroid() {
+        init_logging();
+        let mut runner = TestRunner::new().matching_filename_glob("*Centroid.xml");
+        runner.run().expect("test cases failed");
+
+        // sanity check that *something* was run
+        assert!(
+            runner.failures().len() + runner.successes().len() > 0,
+            "No tests were run."
+        );
+
+        if !runner.failures().is_empty() {
+            let failure_text = runner
+                .failures()
+                .iter()
+                .map(|failure| format!("{}", failure))
+                .collect::<Vec<String>>()
+                .join("\n");
+            panic!(
+                "{} failures / {} successes in JTS test suite:\n{}",
+                runner.failures().len(),
+                runner.successes().len(),
+                failure_text
+            );
+        }
+    }
+
+    #[test]
+    // several of the ConvexHull tests are currently failing
+    #[ignore]
+    fn test_all_general() {
+        init_logging();
+        let mut runner = TestRunner::new();
+        runner.run().expect("test cases failed");
+
+        // sanity check that *something* was run
+        assert!(
+            runner.failures().len() + runner.successes().len() > 0,
+            "No tests were run."
+        );
+
+        if !runner.failures().is_empty() {
+            let failure_text = runner
+                .failures()
+                .iter()
+                .map(|failure| format!("{}", failure))
+                .collect::<Vec<String>>()
+                .join("\n");
+            panic!(
+                "{} failures / {} successes in JTS test suite:\n{}",
+                runner.failures().len(),
+                runner.successes().len(),
+                failure_text
+            );
+        }
+    }
+}

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,0 +1,247 @@
+use include_dir::{include_dir, Dir, DirEntry};
+use approx::relative_eq;
+
+use geo::Geometry;
+use super::{input, Operation, Result};
+
+const GENERAL_TEST_XML: Dir = include_dir!("resources/testxml/general");
+
+#[derive(Debug, Default)]
+pub struct TestRunner {
+    filename_filter: Option<String>,
+    desc_filter: Option<String>,
+    failures: Vec<TestFailure>,
+    unsupported: Vec<TestCase>,
+    successes: Vec<TestCase>,
+}
+
+#[derive(Debug)]
+pub struct TestCase {
+    test_file_name: String,
+    description: String,
+    operation: Operation,
+}
+
+#[derive(Debug)]
+pub struct TestFailure {
+    error_description: String,
+    test_case: TestCase,
+}
+
+impl std::fmt::Display for TestFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        write!(
+            f,
+            "failed {} case \"{}\" with error: {}",
+            &self.test_case.test_file_name, &self.test_case.description, &self.error_description
+        )
+    }
+}
+
+impl TestRunner {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn successes(&self) -> &Vec<TestCase> {
+        &self.successes
+    }
+
+    pub fn failures(&self) -> &Vec<TestFailure> {
+        &self.failures
+    }
+
+    /// `desc`: when specified runs just the test described by `desc`, otherwise all tests are run
+    pub fn matching_desc(mut self, desc: &str) -> Self {
+        self.desc_filter = Some(desc.to_string());
+        self
+    }
+
+    pub fn matching_filename_glob(mut self, filename: &str) -> Self {
+        self.filename_filter = Some(filename.to_string());
+        self
+    }
+
+    pub fn run(&mut self) -> Result<()> {
+        let cases = self.parse_cases()?;
+        debug!("cases.len(): {}", cases.len());
+
+        for test_case in cases {
+            match &test_case.operation {
+                Operation::Centroid { subject, expected } => {
+                    use geo::prelude::Centroid;
+                    match (subject.centroid(), expected) {
+                        (None, None) => {
+                            debug!("Centroid success: None == None");
+                            self.successes.push(test_case);
+                        }
+                        (Some(actual), Some(expected)) if relative_eq!(actual, expected) => {
+                            debug!("Centroid success: actual == expected");
+                            self.successes.push(test_case);
+                        }
+                        (actual, expected) => {
+                            debug!("Centroid failure: actual != expected");
+                            let error_description =
+                                format!("expected {:?}, actual: {:?}", expected, actual);
+                            self.failures.push(TestFailure {
+                                test_case,
+                                error_description,
+                            });
+                        }
+                    }
+                }
+                Operation::ConvexHull { subject, expected } => {
+                    use geo::prelude::ConvexHull;
+
+                    let actual_polygon = match subject {
+                        Geometry::MultiPoint(g) => g.convex_hull(),
+                        Geometry::Point(_g) => {
+                            debug!("ConvexHull not implemented for this geometry (yet?)");
+                            self.unsupported.push(test_case);
+                            continue;
+                        },
+                        Geometry::Line(_g) => {
+                            debug!("ConvexHull not implemented for this geometry (yet?)");
+                            self.unsupported.push(test_case);
+                            continue;
+                        }
+                        Geometry::LineString(_g) => {
+                            debug!("ConvexHull not implemented for this geometry (yet?)");
+                            self.unsupported.push(test_case);
+                            continue;
+                        }
+                        Geometry::Polygon(g) => g.convex_hull(),
+                        Geometry::MultiLineString(_g) => {
+                            debug!("ConvexHull not implemented for this geometry (yet?)");
+                            self.unsupported.push(test_case);
+                            continue;
+                        }
+                        Geometry::MultiPolygon(_g) => {
+                            debug!("ConvexHull not implemented for this geometry (yet?)");
+                            self.unsupported.push(test_case);
+                            continue;
+                        }
+                        Geometry::GeometryCollection(_g) => {
+                            debug!("ConvexHull not implemented for this geometry (yet?)");
+                            self.unsupported.push(test_case);
+                            continue;
+                        }
+                        Geometry::Rect(_g) => {
+                            debug!("ConvexHull not implemented for this geometry (yet?)");
+                            self.unsupported.push(test_case);
+                            continue;
+                        }
+                        Geometry::Triangle(_g) => {
+                            debug!("ConvexHull doesn't support this geometry (yet?)");
+                            self.unsupported.push(test_case);
+                            continue;
+                        }
+                    };
+
+                    // JTS returns a variety of Geometry types depending on the convex hull
+                    // whereas geo *alway* returns a polygon
+                    //
+                    // This is currently the cause of some test failures.
+                    let actual = Geometry::from(actual_polygon);
+                    if relative_eq!(actual, expected) {
+                        debug!("ConvexHull success: actual == expected");
+                        self.successes.push(test_case);
+                    } else {
+                        debug!("ConvexHull failure: actual != expected");
+                        let error_description =
+                            format!("expected {:?}, actual: {:?}", expected, actual);
+                        self.failures.push(TestFailure {
+                            test_case,
+                            error_description,
+                        });
+                    }
+                }
+            }
+        }
+        info!("successes: {}, failures: {}", self.successes.len(), self.failures.len());
+        Ok(())
+    }
+
+    fn parse_cases(&self) -> Result<Vec<TestCase>> {
+        let mut cases = vec![];
+
+        let filename_filter = if let Some(filter) = &self.filename_filter {
+            format!("{}", filter)
+        } else {
+            format!("**/*.xml")
+        };
+
+        for entry in GENERAL_TEST_XML.find(&filename_filter)? {
+            let file = match entry {
+                DirEntry::Dir(_) => { debug_assert!(false, "unexpectedly found dir.xml"); continue }
+                DirEntry::File(file) => file
+            };
+            debug!("deserializing from {:?}", file.path());
+            let file_reader = std::io::BufReader::new(file.contents());
+            let run: input::Run = match serde_xml_rs::from_reader(file_reader) {
+                Ok(r) => r,
+                Err(err) => {
+                    error!(
+                        "skipping invalid test input: {:?}. error: {:?}",
+                        file.path(),
+                        err
+                    );
+                    continue;
+                }
+            };
+            for case in run.cases {
+                if let Some(desc_filter) = &self.desc_filter {
+                    if case.desc.as_str() != desc_filter {
+                        debug!("filter skipped case: {}", &case.desc);
+                        continue;
+                    } else {
+                        debug!("filter matched case: {}", &case.desc);
+                    }
+                } else {
+                    debug!("parsing case {}:", &case.desc);
+                }
+
+                let geometry = match geometry_try_from_wkt_str(&case.a) {
+                    Ok(g) => g,
+                    Err(e) => {
+                        warn!("skipping case after failing to parse wkt into geometry: {:?}", e);
+                        continue;
+                    }
+                };
+
+                for test in case.tests {
+                    let description = case.desc.clone();
+
+                    let test_file_name = file
+                        .path()
+                        .file_name()
+                        .expect("file from include_dir unexpectedly missing name")
+                        .to_string_lossy()
+                        .to_string();
+
+                    match test.operation_input.into_operation(geometry.clone()) {
+                        Ok(operation) => {
+                            cases.push(TestCase {
+                                description,
+                                test_file_name,
+                                operation,
+                            });
+                        }
+                        Err(e) => {
+                            debug!("skipping unsupported operation: {}", e);
+                            continue;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(cases)
+    }
+}
+
+fn geometry_try_from_wkt_str<T>(wkt_str: &str) -> Result<Geometry<T>>
+    where T: wkt::WktFloat + std::str::FromStr + std::default::Default
+{
+    use std::convert::TryInto;
+    Ok(wkt::Wkt::from_str(&wkt_str)?.try_into()?)
+}


### PR DESCRIPTION
Centroid currently fails some test against master, but the ones that run pass based on the current branch patch (being upstreamed here https://github.com/georust/geo/pull/629).

We still skip a couple of Centroid tests because we don't yet have a way to handle `GEOMETRYCOLLECTION(POINT EMPTY)`, see: https://github.com/georust/wkt/issues/61

Some ConvexHull tests are also failing, but I haven't looked into these failures at all, except to notice that at least some of the failures are because, whereas geo always returns a convex hull polygon, JTS actually will return other types.

/cc @rmanoka