### PR TITLE
Allow checks on rings and polygons to support permutes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,6 @@ mod tests {
 
     #[test]
     // several of the ConvexHull tests are currently failing
-    #[ignore]
     fn test_all_general() {
         init_logging();
         let mut runner = TestRunner::new();


### PR DESCRIPTION
Fixes for convex hull:
1. converts expected geoms: LineString -> Polygon
2. make equality checks accept if the polygon rings are rotated / interiors are permuted

Now, both centroid and conv. hull checks pass.