### PR TITLE
Add test for Intersects predicate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ pretty_env_logger = "*"
 [patch.crates-io]
 geo = { git = "https://github.com/georust/geo", branch = "mkirk/centroid-fixups" }
 geo-types = { git = "https://github.com/georust/geo", branch = "mkirk/centroid-fixups" }
-wkt = { git = "https://github.com/georust/wkt" }
+wkt = { git = "https://github.com/rmanoka/wkt", branch = "rmanoka/jts-test-runner" }

--- a/src/input.rs
+++ b/src/input.rs
@@ -36,13 +36,7 @@ pub(crate) struct Run {
 pub(crate) struct Case {
     #[serde(default)]
     pub(crate) desc: String,
-    // `a` seems to always be a WKT geometry, but until we can handle `POINT EMPTY` this
-    // will error.
-    // see https://github.com/georust/wkt/issues/61
-    //
-    // I also spent some time trying to have serde "try" to deserialize, skipping any
-    // cases that were unparseable, without throwing away the whole thing but eventually ran out of time.
-    // See https://github.com/serde-rs/serde/issues/1583 for a related approach
+
     #[serde(deserialize_with = "wkt::deserialize_geometry")]
     pub(crate) a: Geometry<f64>,
 


### PR DESCRIPTION
Requires changes to wkt; I'm currently using a fork with the changes (support for POINT EMPTY, and LINEARRING).  There are a few test cases where the geometry seems to be in some sort of a base64 format.  Not sure how we should parse that.

All the parsed tests pass for hull, centroid, and intersects.