### PR TITLE
Add `relate` tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,11 @@ wkt = { version = "0.9", features = ["geo-types", "serde"] }
 pretty_env_logger = "*"
 
 [patch.crates-io]
-geo = { git = "https://github.com/georust/geo", branch = "mkirk/centroid-fixups" }
-geo-types = { git = "https://github.com/georust/geo", branch = "mkirk/centroid-fixups" }
+geo = { git = "https://github.com/georust/geo", branch = "mkirk/geomgraph" }
+geo-types = { git = "https://github.com/georust/geo", branch = "mkirk/geomgraph" }
+
+# This branch allows parsing more cases and will eventually be upstreamed.
+#
+# Since we gracefully skip cases which fail to parse, the existing tests will
+# still pass when using the published WKT, but less cases will be executed.
 wkt = { git = "https://github.com/rmanoka/wkt", branch = "rmanoka/jts-test-runner" }

--- a/src/input.rs
+++ b/src/input.rs
@@ -58,8 +58,7 @@ pub(crate) struct Test {
 pub struct CentroidInput {
     pub(crate) arg1: String,
 
-    #[serde(rename = "$value")]
-    #[serde(deserialize_with = "wkt::deserialize_point")]
+    #[serde(rename = "$value", deserialize_with = "wkt::deserialize_point")]
     pub(crate) expected: Option<geo::Point<f64>>,
 }
 
@@ -67,8 +66,7 @@ pub struct CentroidInput {
 pub struct ConvexHullInput {
     pub(crate) arg1: String,
 
-    #[serde(rename = "$value")]
-    #[serde(deserialize_with = "wkt::deserialize_geometry")]
+    #[serde(rename = "$value", deserialize_with = "wkt::deserialize_geometry")]
     pub(crate) expected: geo::Geometry<f64>,
 }
 
@@ -77,8 +75,8 @@ pub struct IntersectsInput {
     pub(crate) arg1: String,
     pub(crate) arg2: String,
 
-    #[serde(rename = "$value")]
-    pub(crate) expected: String,
+    #[serde(rename = "$value", deserialize_with = "deserialize_from_str")]
+    pub(crate) expected: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -86,9 +84,17 @@ pub struct RelateInput {
     pub(crate) arg1: String,
     pub(crate) arg2: String,
 
-    #[serde(rename = "arg3")]
-    #[serde(deserialize_with = "deserialize_intersection_matrix")]
+    #[serde(rename = "arg3", deserialize_with = "deserialize_from_str")]
     pub(crate) expected: IntersectionMatrix,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ContainsInput {
+    pub(crate) arg1: String,
+    pub(crate) arg2: String,
+
+    #[serde(rename = "$value", deserialize_with = "deserialize_from_str")]
+    pub(crate) expected: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -106,6 +112,9 @@ pub(crate) enum OperationInput {
     #[serde(rename = "relate")]
     RelateInput(RelateInput),
 
+    #[serde(rename = "contains")]
+    ContainsInput(ContainsInput),
+
     #[serde(other)]
     Unsupported,
 }
@@ -115,6 +124,11 @@ pub(crate) enum Operation {
     Centroid {
         subject: Geometry<f64>,
         expected: Option<Point<f64>>,
+    },
+    Contains {
+        subject: Geometry<f64>,
+        target: Geometry<f64>,
+        expected: bool,
     },
     ConvexHull {
         subject: Geometry<f64>,
@@ -157,17 +171,10 @@ impl OperationInput {
                     case.b.is_some(),
                     "intersects test case must contain geometry b"
                 );
-                let expected = if input.expected.eq_ignore_ascii_case("true") {
-                    true
-                } else if input.expected.eq_ignore_ascii_case("false") {
-                    false
-                } else {
-                    panic!("expected value was neither \"true\" nor \"false\"");
-                };
                 Ok(Operation::Intersects {
                     subject: geometry.clone(),
                     clip: case.b.clone().expect("no geometry b in case"),
-                    expected,
+                    expected: input.expected,
                 })
             }
             Self::RelateInput(input) => {
@@ -180,6 +187,19 @@ impl OperationInput {
                 Ok(Operation::Relate {
                     a: geometry.clone(),
                     b: case.b.clone().expect("no geometry b in case"),
+                    expected: input.expected,
+                })
+            }
+            Self::ContainsInput(input) => {
+                assert_eq!("A", input.arg1);
+                assert_eq!("B", input.arg2);
+                assert!(
+                    case.b.is_some(),
+                    "intersects test case must contain geometry b"
+                );
+                Ok(Operation::Contains {
+                    subject: geometry.clone(),
+                    target: case.b.clone().expect("no geometry b in case"),
                     expected: input.expected,
                 })
             }
@@ -200,13 +220,12 @@ where
     Option::<Wrapper>::deserialize(deserializer).map(|opt_wrapped| opt_wrapped.map(|w| w.0))
 }
 
-pub fn deserialize_intersection_matrix<'de, D>(
-    deserializer: D,
-) -> std::result::Result<IntersectionMatrix, D::Error>
+pub fn deserialize_from_str<'de, T, D>(deserializer: D) -> std::result::Result<T, D::Error>
 where
+    T: std::str::FromStr,
     D: Deserializer<'de>,
+    <T as std::str::FromStr>::Err: std::fmt::Display,
 {
-    use std::str::FromStr;
     String::deserialize(deserializer)
-        .and_then(|str| IntersectionMatrix::from_str(&str).map_err(serde::de::Error::custom))
+        .and_then(|str| T::from_str(&str).map_err(serde::de::Error::custom))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,9 @@ mod tests {
     }
 
     #[test]
-    fn test_centroid() {
+    fn test_relate() {
         init_logging();
-        let mut runner = TestRunner::new().matching_filename_glob("*Centroid.xml");
+        let mut runner = TestRunner::new().matching_filename_glob("*Relate*.xml");
         runner.run().expect("test cases failed");
 
         // sanity check that *something* was run

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -232,11 +232,11 @@ impl TestRunner {
             };
             for mut case in run.cases {
                 if let Some(desc_filter) = &self.desc_filter {
-                    if case.desc.as_str() != desc_filter {
+                    if case.desc.as_str().contains(desc_filter) {
+                        debug!("filter matched case: {}", &case.desc);
+                    } else {
                         debug!("filter skipped case: {}", &case.desc);
                         continue;
-                    } else {
-                        debug!("filter matched case: {}", &case.desc);
                     }
                 } else {
                     debug!("parsing case {}:", &case.desc);

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -4,7 +4,7 @@ use approx::relative_eq;
 use include_dir::{include_dir, Dir, DirEntry};
 
 use super::{input, Operation, Result};
-use geo::{intersects::Intersects, Coordinate, Geometry, LineString, Polygon};
+use geo::{Coordinate, Geometry, LineString, Polygon, intersects::Intersects, prelude::Contains};
 
 const GENERAL_TEST_XML: Dir = include_dir!("resources/testxml/general");
 
@@ -102,9 +102,112 @@ impl TestRunner {
 
                     // TODO: impl `Contains` for `Geometry` in geo and check that result here too
                     // let direct_actual = subject.contains(target);
+                    let verify_contains_trait = match (subject, target) {
+                        (Geometry::Point(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Point(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Point(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Point(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Point(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Point(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Point(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Point(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Point(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Point(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Line(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Line(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Line(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Line(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Line(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Line(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Line(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Line(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Line(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Line(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::LineString(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::LineString(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::LineString(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::LineString(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::LineString(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::LineString(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::LineString(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::LineString(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::LineString(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::LineString(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Polygon(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Polygon(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Polygon(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Polygon(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Polygon(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Polygon(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Polygon(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Polygon(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Polygon(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Polygon(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPoint(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiPoint(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiPoint(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiPoint(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiPoint(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiPoint(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiPoint(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiPoint(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiPoint(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiPoint(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiLineString(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiLineString(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiLineString(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiLineString(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiLineString(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiLineString(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiLineString(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiLineString(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiLineString(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiLineString(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPolygon(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPolygon(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPolygon(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPolygon(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPolygon(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPolygon(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPolygon(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPolygon(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPolygon(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPolygon(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::GeometryCollection(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::GeometryCollection(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::GeometryCollection(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::GeometryCollection(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::GeometryCollection(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::GeometryCollection(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::GeometryCollection(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::GeometryCollection(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::GeometryCollection(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::GeometryCollection(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Rect(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Rect(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Rect(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Rect(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Rect(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Rect(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Rect(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Rect(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Rect(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Rect(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Triangle(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Triangle(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Triangle(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Triangle(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Triangle(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Triangle(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Triangle(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Triangle(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Triangle(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Triangle(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
+                        _ => { true }
+                    };
 
                     if relate_actual != *expected {
-                        debug!("Intersects failure: relate_actual != expected");
+                        debug!("Contains failure: relate_actual != expected");
                         let error_description = format!(
                             "expected {:?}, relate_actual: {:?}",
                             expected, relate_actual
@@ -113,8 +216,19 @@ impl TestRunner {
                             test_case,
                             error_description,
                         });
+                    } else if !verify_contains_trait {
+                        debug!("Contains failure: relate_actual != contains_trait_impl");
+                        let error_description = format!(
+                            "expected {:?}, contains_trait_impl: {:?}",
+                            expected, !relate_actual
+                        );
+                        self.failures.push(TestFailure {
+                            test_case,
+                            error_description,
+                        });
+
                     } else {
-                        debug!("Intersects success: actual == expected");
+                        debug!("Contains success: actual == expected");
                         self.successes.push(test_case);
                     }
                 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -92,6 +92,32 @@ impl TestRunner {
                         }
                     }
                 }
+                Operation::Contains {
+                    subject,
+                    target,
+                    expected,
+                } => {
+                    use geo::algorithm::relate::Relate;
+                    let relate_actual = subject.relate(target).is_contains();
+
+                    // TODO: impl `Contains` for `Geometry` in geo and check that result here too
+                    // let direct_actual = subject.contains(target);
+
+                    if relate_actual != *expected {
+                        debug!("Intersects failure: relate_actual != expected");
+                        let error_description = format!(
+                            "expected {:?}, relate_actual: {:?}",
+                            expected, relate_actual
+                        );
+                        self.failures.push(TestFailure {
+                            test_case,
+                            error_description,
+                        });
+                    } else {
+                        debug!("Intersects success: actual == expected");
+                        self.successes.push(test_case);
+                    }
+                }
                 Operation::ConvexHull { subject, expected } => {
                     use geo::prelude::ConvexHull;
 
@@ -180,16 +206,20 @@ impl TestRunner {
 
                     if direct_actual != *expected {
                         debug!("Intersects failure: direct_actual != expected");
-                        let error_description =
-                            format!("expected {:?}, direct_actual: {:?}", expected, direct_actual);
+                        let error_description = format!(
+                            "expected {:?}, direct_actual: {:?}",
+                            expected, direct_actual
+                        );
                         self.failures.push(TestFailure {
                             test_case,
                             error_description,
                         });
                     } else if relate_actual != *expected {
                         debug!("Intersects failure: relate_actual != expected");
-                        let error_description =
-                            format!("expected {:?}, relate_actual: {:?}", expected, relate_actual);
+                        let error_description = format!(
+                            "expected {:?}, relate_actual: {:?}",
+                            expected, relate_actual
+                        );
                         self.failures.push(TestFailure {
                             test_case,
                             error_description,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -174,18 +174,29 @@ impl TestRunner {
                     clip,
                     expected,
                 } => {
-                    let actual = subject.intersects(clip);
-                    if actual == *expected {
-                        debug!("Intersects success: actual == expected");
-                        self.successes.push(test_case);
-                    } else {
-                        debug!("Intersects failure: actual != expected");
+                    use geo::algorithm::relate::Relate;
+                    let direct_actual = subject.intersects(clip);
+                    let relate_actual = subject.relate(clip).is_intersects();
+
+                    if direct_actual != *expected {
+                        debug!("Intersects failure: direct_actual != expected");
                         let error_description =
-                            format!("expected {:?}, actual: {:?}", expected, actual);
+                            format!("expected {:?}, direct_actual: {:?}", expected, direct_actual);
                         self.failures.push(TestFailure {
                             test_case,
                             error_description,
                         });
+                    } else if relate_actual != *expected {
+                        debug!("Intersects failure: relate_actual != expected");
+                        let error_description =
+                            format!("expected {:?}, relate_actual: {:?}", expected, relate_actual);
+                        self.failures.push(TestFailure {
+                            test_case,
+                            error_description,
+                        });
+                    } else {
+                        debug!("Intersects success: actual == expected");
+                        self.successes.push(test_case);
                     }
                 }
                 Operation::Relate { a, b, expected } => {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -141,9 +141,7 @@ impl TestRunner {
                     };
 
                     // JTS returns a variety of Geometry types depending on the convex hull
-                    // whereas geo *alway* returns a polygon
-                    //
-                    // This is currently the cause of some test failures.
+                    // whereas geo *always* returns a polygon.
                     let expected = match expected {
                         Geometry::LineString(ext) => Polygon::new(ext.clone(), vec![]),
                         Geometry::Polygon(p) => p.clone(),
@@ -182,6 +180,22 @@ impl TestRunner {
                         self.successes.push(test_case);
                     } else {
                         debug!("Intersects failure: actual != expected");
+                        let error_description =
+                            format!("expected {:?}, actual: {:?}", expected, actual);
+                        self.failures.push(TestFailure {
+                            test_case,
+                            error_description,
+                        });
+                    }
+                }
+                Operation::Relate { a, b, expected } => {
+                    use geo::algorithm::relate::Relate;
+                    let actual = a.relate(b);
+                    if actual == *expected {
+                        debug!("Relate success: actual == expected");
+                        self.successes.push(test_case);
+                    } else {
+                        debug!("Relate failure: actual != expected");
                         let error_description =
                             format!("expected {:?}, actual: {:?}", expected, actual);
                         self.failures.push(TestFailure {


### PR DESCRIPTION
This PR adds support for the `relate` tests.

The sister PR which implements this functionality in `geo` is at https://github.com/georust/geo/pull/639