### PR TITLE
Bump to 2021, WKT to 0.10, linting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,15 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     strategy:
       matrix:
-        container_image: ["georust/geo-ci:rust-1.51", "georust/geo-ci:rust-1.57"]
+        container_image:
+          # We aim to support rust-stable plus (at least) the prior 3 releases,
+          # giving us about 6 months of coverage.
+          #
+          # Minimum supported rust version (MSRV)
+          - "georust/geo-ci:rust-1.56"
+          # Two most recent releases - we omit older ones for expedient CI
+          - "georust/geo-ci:rust-1.58"
+          - "georust/geo-ci:rust-1.59"
     container:
       image: ${{ matrix.container_image }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 /target
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,7 @@
 name = "jts-test-runner"
 version = "0.1.0"
 authors = ["Michael Kirk <michael.code@endoftheworl.de>"]
-edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition = "2021"
 
 [dependencies]
 approx = "0.4.0"
@@ -13,8 +11,7 @@ include_dir = { version = "0.6", features = ["search"] }
 log = "0.4.14"
 serde =  { version = "*", features = ["derive"] }
 serde-xml-rs = "*"
-wkt = { version = "0.9", features = ["geo-types", "serde"] }
+wkt = { version = "0.10.0", features = ["geo-types", "serde"] }
 
 [dev-dependencies]
 pretty_env_logger = "*"
-

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 A tool used to compare the behavior of [GeoRust/geo] to the venerable
 [JTS](https://www.osgeo.org/projects/jts/).
 
-In particular, the contents of [./resources/testxml](./resources/testxml) were copied from 
-[JTS's test files](https://github.com/locationtech/jts/blob/master/modules/tests/src/test/resources/testxml).
+In particular, the contents of [./resources/testxml](./resources/testxml) were copied from [JTS's test files](https://github.com/locationtech/jts/blob/master/modules/tests/src/test/resources/testxml).
 
 ```
 # Run only the centroid tests
@@ -19,22 +18,18 @@ runner.run().expect("test cases failed");
 ## GeoRust is Incomplete
 
 Not all tests are handled, in part because JTS supports a lot of things
-[GeoRust/geo] doen't support (yet!). 
+[GeoRust/geo] doesn't support (yet!). 
 
-For some of the things which _are_ supported, [GeoRust/geo] might diverge. This
-is probably a bug, and should be investigated - precisely what this test runner
-is built to find!
+For some things which _are_ supported, [GeoRust/geo] might diverge. This  is probably a bug, and should be investigated - precisely what this test runner is built to find!
 
 ### Parsing New Test Case Input
 
 Parsing test case input happens in [OperationInput](./src/input.rs#L77). 
 
-Each type of test (Centroid, ConcaveHull, etc.) has different inputs, so will
-need to be handled slightly differently.
+Each type of test (Centroid, ConcaveHull, etc.) has different inputs, so will need to be handled slightly differently.
 
 ### Running New Test Cases
 
-Evaluating [GeoRust/geo] behavior against the expectations in the test case
-input happens in [TestRunner#run](./src/runner.rs#65)
+Evaluating [GeoRust/geo] behavior against the expectations in the test case input happens in [TestRunner#run](./src/runner.rs#65)
 
 [GeoRust/geo]: https://github.com/georust/geo

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate log;
-
 mod input;
 use input::Operation;
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2,9 +2,10 @@ use std::collections::BTreeSet;
 
 use approx::relative_eq;
 use include_dir::{include_dir, Dir, DirEntry};
+use log::{debug, info};
 
 use super::{input, Operation, Result};
-use geo::{Coordinate, Geometry, LineString, Polygon, intersects::Intersects, prelude::Contains};
+use geo::{intersects::Intersects, prelude::Contains, Coordinate, Geometry, LineString, Polygon};
 
 const GENERAL_TEST_XML: Dir = include_dir!("resources/testxml/general");
 
@@ -203,7 +204,7 @@ impl TestRunner {
                         // (Geometry::Triangle(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Triangle(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Triangle(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
-                        _ => { true }
+                        _ => true,
                     };
 
                     if relate_actual != *expected {
@@ -373,9 +374,9 @@ impl TestRunner {
         let mut cases = vec![];
 
         let filename_filter = if let Some(filter) = &self.filename_filter {
-            format!("{}", filter)
+            filter.to_string()
         } else {
-            format!("**/*.xml")
+            "**/*.xml".to_string()
         };
 
         for entry in GENERAL_TEST_XML.find(&filename_filter)? {
@@ -410,7 +411,7 @@ impl TestRunner {
                 } else {
                     debug!("parsing case {}:", &case.desc);
                 }
-                let tests = std::mem::replace(&mut case.tests, vec![]);
+                let tests = std::mem::take(&mut case.tests);
                 for test in tests {
                     let description = case.desc.clone();
 
@@ -458,7 +459,7 @@ where
     let mut matched_in_p2: BTreeSet<usize> = BTreeSet::new();
     for r1 in p1.interiors().iter() {
         let did_match = p2.interiors().iter().enumerate().find(|(j, r2)| {
-            !matched_in_p2.contains(&j) && is_ring_rotated_eq(r1, r2, &coord_matcher)
+            !matched_in_p2.contains(j) && is_ring_rotated_eq(r1, r2, &coord_matcher)
         });
         if let Some((j, _)) = did_match {
             matched_in_p2.insert(j);
@@ -466,7 +467,7 @@ where
             return false;
         }
     }
-    return true;
+    true
 }
 
 /// Test if two rings are equal upto rotation / reversal


### PR DESCRIPTION
* Bump Rust edition to 2021
* Address a few `cargo clippy` suggestions
* Bump WKT dependency 0.9 -> 0.10
* few minor spelling fixes

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- ~[ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.~
---

